### PR TITLE
examples: use APIs from aws-iot-expresslink library in examples

### DIFF
--- a/sketches/arduino_sample_sketch.ino
+++ b/sketches/arduino_sample_sketch.ino
@@ -1,22 +1,19 @@
 #include <SoftwareSerial.h>
+#include <ExpressLink.h>
 
 #define SERIAL_RX_PIN   8
 #define SERIAL_TX_PIN   9
 
+// If a pin is not used, set its value to -1
 #define EVENT_PIN 2
+#define WAKE_PIN  -1
 #define RESET_PIN 4
 
-#define MY_AWS_IOT_ENDPOINT "<hash>-ats.iot.<region>.amazonaws.com"
+#define DEBUG_ENABLE false
 
-typedef enum event_t {
-    EVENT_NONE = 0,
-    EVENT_STARTUP = 2,
-    EVENT_CONLOST,
-    EVENT_OVERRUN,
-    EVENT_OTA,
-    EVENT_SHADOW,
-    EVENT_CONFMODE,
-} event_t;
+#define MY_AWS_IOT_ENDPOINT "<hash>-ats.iot.us-east-1.amazonaws.com"
+
+ExpressLink el;
 
 typedef enum {
     STATE_INIT = 0,
@@ -28,47 +25,12 @@ typedef enum {
     STATE_CONNECTED,
 } state_t;
 
-String execute_command(String command, unsigned long timeout_ms)
-{
-    unsigned long saved_timeout_value_ms = Serial.getTimeout();
-    Serial.setTimeout(timeout_ms);
-    Serial.println(command);
-    String s = Serial.readStringUntil('\n');
-    s.trim();
-    Serial.setTimeout(saved_timeout_value_ms);
-    return s;
-}
 
 void expresslink_reset()
 {
     digitalWrite(RESET_PIN, LOW);
     delay(200);
     digitalWrite(RESET_PIN, HIGH);
-}
-
-event_t process_event()
-{
-    int val = 0;
-    event_t event_number = EVENT_NONE;
-    String response;
-    val = digitalRead(EVENT_PIN);
-    if(val)
-    {
-        response = execute_command("AT+EVENT?", 3000);
-        if (response.equals("OK"))
-        {
-            return EVENT_NONE;
-        }
-        else {
-            char ok_string[3];
-            int topic_index;
-            int total_read;
-
-            total_read = sscanf(response.c_str(), "%s %d %d %*s" , ok_string, &event_number, &topic_index);
-
-            return event_number;
-        }
-    }
 }
 
 state_t process_ssid(String response)
@@ -91,83 +53,77 @@ state_t process_ssid(String response)
 void setup()
 {
     SoftwareSerial mySerial(SERIAL_RX_PIN, SERIAL_TX_PIN);
-    Serial.begin(115200);
+    Serial.begin(ExpressLink::BAUDRATE);
     mySerial.begin(115200);
-    pinMode(EVENT_PIN, INPUT);
     pinMode(RESET_PIN, OUTPUT);
-    while (!Serial) {
-        ;
-    }
-    while (!mySerial) {
-        ;
+    while (!Serial) { ; }
+    while (!mySerial) { ; }
+    expresslink_reset();
+    delay(5000); // Wait for ExpressLink board to restart
+    if (!el.begin(Serial, EVENT_PIN, WAKE_PIN, RESET_PIN, DEBUG_ENABLE)) {
+      mySerial.println("Failed to initialize ExpressLink.");
+      while (true) { ; }
     }
 }
 
+static state_t state = STATE_INIT;
+
 void loop()
 {
-    event_t event = EVENT_NONE;
-    String response;
-    static state_t state = STATE_INIT;
-
-    if (state != STATE_INIT)
-    {
-        event = process_event();
+    ExpressLink::EventCode event = ExpressLink::EventCode::NONE;
+    if (state != STATE_INIT) {
+        ExpressLink::Event e = el.getEvent();
+        event = e.code;
     }
 
     switch (state) {
 
         case STATE_INIT:
-        expresslink_reset();
-        state = STATE_WAIT_EL_READY;
-        break;
+            state = STATE_WAIT_EL_READY;
+            break;
 
         case STATE_WAIT_EL_READY:
-        if (event == EVENT_STARTUP) {
-            state = STATE_EL_READY;
-        }
-        break;
+            if (event == ExpressLink::EventCode::STARTUP) {
+                state = STATE_EL_READY;
+            }
+            break;
 
         case STATE_EL_READY:
-        response = execute_command("AT+CONF Endpoint="MY_AWS_IOT_ENDPOINT"", 3000);
-        response = execute_command("AT+CONF Topic1=TEST", 3000);
-        response = execute_command("AT+CONF? SSID", 3000);
-        state = process_ssid(response);
-
-        break;
+            el.config.setEndpoint(MY_AWS_IOT_ENDPOINT);
+            el.config.setTopic(1, "TEST");
+            state = process_ssid(el.config.getSSID());
+            break;
 
         case STATE_UNPROVISIONED:
-        response = execute_command("AT+CONFMODE", 5000);
-        if (response.equals("OK CONFMODE ENABLED"))
-        {
-            state = STATE_PROVISIONING;
-        }
-        break;
+            if (el.cmd("CONFMODE")) {
+                state = STATE_PROVISIONING;
+            }
+            break;
 
         case STATE_PROVISIONING:
-        if (event == EVENT_CONFMODE) {
-            state = STATE_PROVISIONED;
-        }
-        break;
+            if (event == ExpressLink::EventCode::CONFMODE) {
+                state = STATE_PROVISIONED;
+            }
+            break;
 
         case STATE_PROVISIONED:
-        response = execute_command("AT+CONNECT", 30000);
-        if (response.equals("OK 1 CONNECTED")) {
-            state = STATE_CONNECTED;
-        }
-        break;
+            if (el.connect()) {
+                state = STATE_CONNECTED;
+            }
+            break;
 
         case STATE_CONNECTED:
-        if (event == EVENT_CONLOST)
-        {
-            state = STATE_PROVISIONED;
+            if (event == ExpressLink::EventCode::CONLOST)
+            {
+                state = STATE_PROVISIONED;
+                break;
+            }
+            static unsigned long last_send_time;
+            if (millis() - last_send_time >= 10000)
+            {
+                el.publish(1, "Hello World");
+                last_send_time = millis();
+            }
             break;
-        }
-        static unsigned long last_send_time;
-        if (millis() - last_send_time >= 10000)
-        {
-            response = execute_command("AT+SEND1 Hello World", 5000);
-            last_send_time = millis();
-        }
-        break;
     }
 }

--- a/sketches/arduino_sample_sketch_new.ino
+++ b/sketches/arduino_sample_sketch_new.ino
@@ -1,0 +1,81 @@
+#include <SoftwareSerial.h>
+#include <ExpressLink.h>
+
+#define SERIAL_RX_PIN   8
+#define SERIAL_TX_PIN   9
+
+// If a pin is not used, set its value to -1
+#define EVENT_PIN 2
+#define WAKE_PIN  -1
+#define RESET_PIN 4
+
+#define DEBUG_ENABLE false
+
+#define MY_AWS_IOT_ENDPOINT "<hash>-ats.iot.us-east-1.amazonaws.com"
+
+ExpressLink el;
+
+void expresslink_reset()
+{
+    digitalWrite(RESET_PIN, LOW);
+    delay(200);
+    digitalWrite(RESET_PIN, HIGH);
+}
+
+bool process_ssid(String response)
+{
+    int event_number = 0;
+    char ok_string[3];
+    char ssid_string[33] = {0};
+    int total_read;
+
+    total_read = sscanf(response.c_str(), "%s %s" , ok_string, ssid_string);
+
+    if (total_read > 1) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+void setup()
+{
+    SoftwareSerial mySerial(SERIAL_RX_PIN, SERIAL_TX_PIN);
+    Serial.begin(ExpressLink::BAUDRATE);
+    mySerial.begin(115200);
+    pinMode(RESET_PIN, OUTPUT);
+    while (!Serial) { ; }
+    while (!mySerial) { ; }
+    expresslink_reset();
+    delay(5000); // Wait for ExpressLink board to restart
+    int count = 0;
+    while (!el.begin(Serial, EVENT_PIN, WAKE_PIN, RESET_PIN, DEBUG_ENABLE)) {
+      count++;
+      if (count > 2) {
+        mySerial.println("Failed to initialize ExpressLink.");
+        while (true) { ; }
+      }
+    }
+    el.config.setEndpoint(MY_AWS_IOT_ENDPOINT);
+    el.config.setTopic(1, "TEST");
+    bool enable_conf_mode = false;
+    if (!process_ssid(el.config.getSSID())) {
+      el.cmd("CONFMODE");
+      while (el.getEvent().code != ExpressLink::EventCode::CONFMODE) {
+        delay(2000); // Wait for WiFi-provisioning
+      }
+    }
+}
+
+void loop()
+{
+    if (!el.isConnected()) {
+        el.connect();
+    }
+    static unsigned long last_send_time;
+    if (millis() - last_send_time >= 10000) {
+        el.publish(1, "Hello World");
+        last_send_time = millis();
+    }
+    delay(100);
+}


### PR DESCRIPTION
- Update examples with new aws-iot-expresslink APIs
- Add a new example that removes the state machine used in previous example.
cc: @dhavalgujar 